### PR TITLE
Fix: Client initialized event callback value is always false

### DIFF
--- a/client.js
+++ b/client.js
@@ -271,7 +271,7 @@ function checkAllInitialized() {
 
   users.forEach( function( user ) {
 
-    isAllInited = data[ 'pv_init' + user ] && isAllInited;
+    isAllInited = data[ 'pv_init/#' + user ] && isAllInited;
   });
 
   if( this.isAllInitialized !== isAllInited ) {

--- a/client.js
+++ b/client.js
@@ -271,7 +271,7 @@ function checkAllInitialized() {
 
   users.forEach( function( user ) {
 
-    isAllInited = data[ 'pv_init/#' + user ] && isAllInited;
+    isAllInited = Boolean(data[ 'pv_init/#' + user ]) && isAllInited;
   });
 
   if( this.isAllInitialized !== isAllInited ) {


### PR DESCRIPTION
## Problem
- The function `checkAllInitialized` never emits the event `initialized` (with value `true`) cause `isAllInited` never gets the chance to be `true`.

## Solution
- Add `/#` to the comparison cause thats how the value in `data` has it.

## Comments
- The `/#` is added in `setIsInitialized` as part of a fix with **socket.io-client** (already commented on the file).
- Also added Boolean coercion so when the user data is not found, `isAllInited` value is not `undefined` but `false`. Not changing the value of `this.isAllInitialized` from `false` to `undefined`.
- @PeterAltamirano don't know who else to add as a Reviewer.